### PR TITLE
refactor: code quality, performance, and error handling improvements

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "ui",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": ["-c", "cd /Users/timbrandle/dev/resume_builder/ui && npm start"],
+      "port": 3000
+    },
+    {
+      "name": "server",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": ["-c", "cd /Users/timbrandle/dev/resume_builder/server && set -a && source .env.local && set +a && npm run start:dev"],
+      "port": 8080
+    }
+  ]
+}

--- a/server/controllers/resumes.ts
+++ b/server/controllers/resumes.ts
@@ -9,8 +9,12 @@ export const getAllResumes = async (
   res: Response,
   next: NextFunction
 ) => {
-  const allResumes = await prisma.resume.findMany();
-  res.status(200).send(allResumes);
+  try {
+    const allResumes = await prisma.resume.findMany();
+    res.status(200).send(allResumes);
+  } catch (error) {
+    next(error);
+  }
 };
 
 export const getListIds = async (
@@ -19,7 +23,9 @@ export const getListIds = async (
   next: NextFunction
 ) => {
   try {
-    const allResumes = await prisma.resume.findMany();
+    const allResumes = await prisma.resume.findMany({
+      select: { id: true, resume: true },
+    });
     res.status(200).send(
       allResumes.map(({ resume, id }) => {
         const resumeObject = resume as Prisma.JsonObject;
@@ -27,8 +33,7 @@ export const getListIds = async (
       })
     );
   } catch (error) {
-    console.log(error);
-    res.sendStatus(500);
+    next(error);
   }
 };
 
@@ -37,16 +42,20 @@ export const getSingleResume = async (
   res: Response,
   next: NextFunction
 ) => {
-  const response = await prisma.resume.findUnique({
-    where: { id: req.params.id },
-  });
+  try {
+    const response = await prisma.resume.findUnique({
+      where: { id: req.params.id },
+    });
 
-  if (!response) {
-    return next(new NotFoundException("Resume not found."));
+    if (!response) {
+      return next(new NotFoundException("Resume not found."));
+    }
+
+    const resumeObj = response.resume as Prisma.JsonObject;
+    res.status(200).send({ ...resumeObj, id: response.id });
+  } catch (error) {
+    next(error);
   }
-
-  const resumeObj = response?.resume as Prisma.JsonObject;
-  res.status(200).send({ ...resumeObj, id: response?.id });
 };
 
 export const createResume = async (
@@ -61,20 +70,14 @@ export const createResume = async (
       },
     });
 
-    if (!resume) {
-      return next(
-        new BadRequestException("Something went wrong! Resume was not created.")
-      );
-    }
-
     res
-      .status(200)
+      .status(201)
       .send({ message: `Successfully added resume`, id: resume.id });
   } catch (error) {
-    console.log(error);
-    res.sendStatus(500);
+    next(error);
   }
 };
+
 export const updateResume = async (
   req: Request,
   res: Response,
@@ -90,19 +93,25 @@ export const updateResume = async (
       },
     });
 
-    if (!resume) {
-      return next(new NotFoundException("Resume not found."));
-    }
-
     res
       .status(200)
       .send({ message: `Successfully updated resume`, id: resume.id });
   } catch (error) {
-    console.log(error);
-    res.sendStatus(500);
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2025"
+    ) {
+      return next(new NotFoundException("Resume not found."));
+    }
+    next(error);
   }
 };
-export const deleteResume = async (req: Request, res: Response) => {
+
+export const deleteResume = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const resume = await prisma.resume.delete({
       where: {
@@ -114,7 +123,12 @@ export const deleteResume = async (req: Request, res: Response) => {
       .status(200)
       .send({ message: `Successfully deleted resume`, id: resume.id });
   } catch (error) {
-    console.log(error);
-    res.sendStatus(500);
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2025"
+    ) {
+      return next(new NotFoundException("Resume not found."));
+    }
+    next(error);
   }
 };

--- a/server/middlewares/errors.ts
+++ b/server/middlewares/errors.ts
@@ -2,7 +2,6 @@ import { NextFunction, Request, Response } from "express";
 import { HttpException } from "../exceptions/root";
 
 export const errorMiddleware = (error:HttpException, req:Request, res:Response, next:NextFunction) => {
-  console.log(error.message)
   res.status(error.statusCode).json({
     message: error.message,
     errors: error.errors

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,19 +1,20 @@
 import express from "express";
-import { Prisma } from "@prisma/client";
-import cors from 'cors';
+import cors from "cors";
 import { errorMiddleware } from "./middlewares/errors";
-// const rootRouter = require("./routes");
 import rootRouter from "./routes";
 import { PrismaClient } from "@prisma/client";
 
 export const prisma = new PrismaClient({
-  log: ['query']
+  log: process.env.NODE_ENV === "development" ? ["query"] : [],
 });
 
 const whitelist = ["http://localhost:3000"];
 
 const corsOptions = {
-  origin: function (origin: any, callback: any) {
+  origin: (
+    origin: string | undefined,
+    callback: (err: Error | null, allow?: boolean) => void
+  ) => {
     if (!origin || whitelist.indexOf(origin) !== -1) {
       callback(null, true);
     } else {
@@ -26,7 +27,7 @@ const app = express();
 app.use(express.json());
 app.use(cors(corsOptions));
 
-app.use('/api', rootRouter)
+app.use("/api", rootRouter);
 app.use(errorMiddleware);
 
 app.listen(process.env.PORT, () =>

--- a/ui/src/components/App/App.tsx
+++ b/ui/src/components/App/App.tsx
@@ -1,7 +1,7 @@
 import Stack from "@mui/material/Stack";
 import "./App.css";
 import PdfView from "../PdfView/PdfView";
-import { useEffect, useMemo, useReducer, useRef, useState } from "react";
+import { useEffect, useReducer, useRef, useState } from "react";
 import { defaultResume } from "../../data/defaultData";
 import resumeReducer, { actionConstants } from "../../reducers/resumeReducer";
 import ResumeForm from "../ResumeForm/ResumeForm";
@@ -10,6 +10,7 @@ import useBuildPdfData from "../../hooks/useBuildPdfData";
 import { useSearchParams } from "react-router-dom";
 import useApi from "../../hooks/useApi";
 import useResizeObserver from "use-resize-observer";
+import { PDF_PAGE_HEIGHT_PX } from "../../constants/pdf";
 
 function App() {
   const [{ resume, isSaved }, dispatch] = useReducer(resumeReducer, {
@@ -20,16 +21,14 @@ function App() {
   const [isBotTheme, setIsBotTheme] = useState(false);
 
   const [searchParams, setSearchParams] = useSearchParams();
-  const params = useMemo(() => searchParams, [searchParams]);
-  const { api, isLoading, error } = useApi();
+  const { api } = useApi();
 
   useEffect(() => {
     const fetchResume = async () => {
-      const resumeId = params.get("resumeId");
+      const resumeId = searchParams.get("resumeId");
       if (resumeId) {
         try {
           const savedResume = await api.get(resumeId);
-          console.log({ savedResume });
           dispatch({
             type: actionConstants.SET_RESUME,
             payload: savedResume,
@@ -41,26 +40,22 @@ function App() {
     };
 
     fetchResume();
-  }, [params, api]);
+  }, [searchParams, api]);
 
   const { ref, height = 0 } = useResizeObserver({
     box: "content-box",
   });
 
-  if (height) {
-    console.log({ height }, new Date(Date.now()).toLocaleString());
-  }
-
   const pdfRef = useRef<HTMLDivElement | null>(null);
 
-  const { personlDetails, socialMedia, skills, employmentHistory, education } =
+  const { personalDetails, socialMedia, skills, employmentHistory, education } =
     useBuildPdfData(resume);
 
   return (
     <>
       <Header
         resume={resume}
-        numberOfPages={Math.ceil(height / 1094)}
+        numberOfPages={Math.ceil(height / PDF_PAGE_HEIGHT_PX)}
         isSaved={isSaved}
         dispatch={dispatch}
         pdfRef={pdfRef}
@@ -76,7 +71,7 @@ function App() {
                 ref={pdfRef}
                 pageRef={ref}
                 isBotTheme={isBotTheme}
-                personalDetails={personlDetails}
+                personalDetails={personalDetails}
                 socialMedia={socialMedia}
                 skills={skills}
                 employmentHistory={employmentHistory}

--- a/ui/src/components/Header/Header.tsx
+++ b/ui/src/components/Header/Header.tsx
@@ -4,6 +4,8 @@ import IconButton from "@mui/material/IconButton";
 import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
 import Select, { SelectChangeEvent } from "@mui/material/Select";
+import Snackbar from "@mui/material/Snackbar";
+import Alert from "@mui/material/Alert";
 import AddCircleOutline from "@mui/icons-material/AddCircleOutline";
 import ContentCopy from "@mui/icons-material/ContentCopy";
 import Delete from "@mui/icons-material/Delete";
@@ -48,6 +50,7 @@ const Header = ({
 }: HeaderProps) => {
   const { api } = useApi();
   const [searchParams, setSearchParams] = useSearchParams();
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   const [selectResumeList, setSelectResumeList] = useState<
     { id: string; title: string }[]
@@ -58,7 +61,7 @@ const Header = ({
       const response = await api.get("list_ids");
       setSelectResumeList(response);
     } catch (error) {
-      console.log({ error });
+      setErrorMsg("Failed to load resume list.");
     }
   }, [setSelectResumeList, api]);
 
@@ -79,7 +82,7 @@ const Header = ({
       const newResume = await api.post(duplicateResume);
       setSearchParams({ resumeId: newResume.id });
     } catch (error) {
-      console.log({ error });
+      setErrorMsg("Failed to duplicate resume. Please try again.");
     }
   };
 
@@ -96,16 +99,21 @@ const Header = ({
       });
       fetchAndSetMasterList();
     } catch (e) {
-      console.error(e);
+      setErrorMsg("Failed to save resume. Please try again.");
     }
   };
 
   const handleDelete = async () => {
     if (resume.id) {
-      await api.delete(resume.id);
-      searchParams.delete("resumeId");
-      setSearchParams(searchParams);
-      fetchAndSetMasterList();
+      try {
+        await api.delete(resume.id);
+        searchParams.delete("resumeId");
+        setSearchParams(searchParams);
+        fetchAndSetMasterList();
+      } catch (error) {
+        setErrorMsg("Failed to delete resume. Please try again.");
+        return;
+      }
     }
     dispatch({
       type: actionConstants.SET_RESUME,
@@ -114,15 +122,19 @@ const Header = ({
   };
 
   const createNewResume = async () => {
-    const { id } = await api.post(defaultResume({ resume_title: "New" }));
-    setSearchParams({ resumeId: id });
+    try {
+      const { id } = await api.post(defaultResume({ resume_title: "New" }));
+      setSearchParams({ resumeId: id });
+    } catch (error) {
+      setErrorMsg("Failed to create resume. Please try again.");
+    }
   };
 
-  const handleSelectResume = async (e: SelectChangeEvent<string>) => {
+  const handleSelectResume = (e: SelectChangeEvent<string>) => {
     setSearchParams({ resumeId: e.target.value });
   };
 
-  const handleBotToggle = async (
+  const handleBotToggle = (
     _e: ChangeEvent<HTMLInputElement>,
     checked: boolean,
   ) => {
@@ -130,69 +142,81 @@ const Header = ({
   };
 
   return (
-    <Stack direction={"row"} className={"headerContainer"}>
-      <Stack direction={"row"} columnGap={4}>
-        <FormControl variant="standard" sx={{ m: 1, minWidth: 300 }}>
-          <InputLabel id="resume-select-label">Select resume</InputLabel>
-          <Select
-            labelId="resume-select-label"
-            id="demo-simple-select"
-            onChange={handleSelectResume}
-            value={
-              selectResumeList.find(
-                (resume) => resume.id === searchParams.get("resumeId"),
-              )?.id || ""
-            }
-          >
-            {selectResumeList.map(({ id, title }, i) => {
-              return (
-                <MenuItem key={`${id}-${i}`} value={id}>
-                  {" "}
-                  {title}
-                </MenuItem>
-              );
-            })}
-          </Select>
-        </FormControl>
-        <BotToggle checked={isBotTheme} onChange={handleBotToggle} />
-      </Stack>
-      <div className={"numberOfPages"}>
-        {numberOfPages} {numberOfPages < 2 ? "page" : "pages"}
-      </div>
-      <Stack direction={"row"} columnGap={3} alignItems="center">
-        <Tooltip title="New resume">
-          <IconButton className={"iconButton"} onClick={createNewResume}>
-            <AddCircleOutline />
-          </IconButton>
-        </Tooltip>
-        <Tooltip title="Download PDF">
-          <IconButton className={"iconButton"} onClick={handlePrint}>
-            <Download />
-          </IconButton>
-        </Tooltip>
-        <Tooltip title="Duplicate">
-          <IconButton className={"iconButton"} onClick={handleDuplicate}>
-            <ContentCopy />
-          </IconButton>
-        </Tooltip>
-        <Tooltip title="Save">
-          <span>
-            <IconButton
-              className={"iconButton"}
-              onClick={handleSave}
-              disabled={isSaved}
+    <>
+      <Stack direction={"row"} className={"headerContainer"}>
+        <Stack direction={"row"} columnGap={4}>
+          <FormControl variant="standard" sx={{ m: 1, minWidth: 300 }}>
+            <InputLabel id="resume-select-label">Select resume</InputLabel>
+            <Select
+              labelId="resume-select-label"
+              id="demo-simple-select"
+              onChange={handleSelectResume}
+              value={
+                selectResumeList.find(
+                  (resume) => resume.id === searchParams.get("resumeId"),
+                )?.id || ""
+              }
             >
-              <Save />
+              {selectResumeList.map(({ id, title }, i) => {
+                return (
+                  <MenuItem key={`${id}-${i}`} value={id}>
+                    {" "}
+                    {title}
+                  </MenuItem>
+                );
+              })}
+            </Select>
+          </FormControl>
+          <BotToggle checked={isBotTheme} onChange={handleBotToggle} />
+        </Stack>
+        <div className={"numberOfPages"}>
+          {numberOfPages} {numberOfPages < 2 ? "page" : "pages"}
+        </div>
+        <Stack direction={"row"} columnGap={3} alignItems="center">
+          <Tooltip title="New resume">
+            <IconButton className={"iconButton"} onClick={createNewResume}>
+              <AddCircleOutline />
             </IconButton>
-          </span>
-        </Tooltip>
-        <Tooltip title="Delete">
-          <IconButton className={"iconButton"} onClick={handleDelete}>
-            <Delete />
-          </IconButton>
-        </Tooltip>
+          </Tooltip>
+          <Tooltip title="Download PDF">
+            <IconButton className={"iconButton"} onClick={handlePrint}>
+              <Download />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Duplicate">
+            <IconButton className={"iconButton"} onClick={handleDuplicate}>
+              <ContentCopy />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Save">
+            <span>
+              <IconButton
+                className={"iconButton"}
+                onClick={handleSave}
+                disabled={isSaved}
+              >
+                <Save />
+              </IconButton>
+            </span>
+          </Tooltip>
+          <Tooltip title="Delete">
+            <IconButton className={"iconButton"} onClick={handleDelete}>
+              <Delete />
+            </IconButton>
+          </Tooltip>
+        </Stack>
       </Stack>
-    </Stack>
+      <Snackbar
+        open={!!errorMsg}
+        autoHideDuration={4000}
+        onClose={() => setErrorMsg(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+      >
+        <Alert severity="error" onClose={() => setErrorMsg(null)}>
+          {errorMsg}
+        </Alert>
+      </Snackbar>
+    </>
   );
 };
 

--- a/ui/src/components/PdfView/PdfView.tsx
+++ b/ui/src/components/PdfView/PdfView.tsx
@@ -32,7 +32,6 @@ const PdfView = React.forwardRef<HTMLDivElement | null, PdfViewProps>(
       isBotTheme,
       pageRef,
     } = props;
-    console.log("rerender");
     return (
       <div className="pageContainer">
         <div ref={ref}>
@@ -198,4 +197,4 @@ const PdfView = React.forwardRef<HTMLDivElement | null, PdfViewProps>(
   },
 );
 
-export default PdfView;
+export default React.memo(PdfView);

--- a/ui/src/components/ResumeForm/ResumeForm.tsx
+++ b/ui/src/components/ResumeForm/ResumeForm.tsx
@@ -1,12 +1,15 @@
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Stack from "@mui/material/Stack";
+import React, { useCallback } from "react";
 import { Action, actionConstants } from "../../reducers/resumeReducer";
 import { Field, Resume } from "../../types/resumeTypes";
 import "react-quill/dist/quill.snow.css";
 import { FormSection } from "./FormSection";
 import "./ResumeForm.css";
 import SortableColumn from "./SortableColumn";
+import SortableItemSummary from "./SortableItemSummary";
+import SectionTitle from "../shared/SectionTitle";
 import TextField from "@mui/material/TextField";
 
 const ResumeForm = ({
@@ -16,6 +19,96 @@ const ResumeForm = ({
   resume: Resume;
   dispatch: React.Dispatch<Action>;
 }) => {
+  const handleUpdatePersonalDetails = useCallback(
+    (payload: Field) =>
+      dispatch({ type: actionConstants.UPDATE_PERSONAL_DETAILS, payload }),
+    [dispatch],
+  );
+
+  const handleUpdateSocialMedia = useCallback(
+    (payload: Field) =>
+      dispatch({ type: actionConstants.UPDATE_SOCIAL_MEDIA, payload }),
+    [dispatch],
+  );
+
+  const handleSkillsUpdate = useCallback(
+    (parentId: string) => (fieldPayload: Field) =>
+      dispatch({
+        type: actionConstants.UPDATE_SKILLS,
+        payload: { parentId, fieldPayload },
+      }),
+    [dispatch],
+  );
+
+  const handleSkillsDelete = useCallback(
+    (parentId: string) => () =>
+      dispatch({ type: actionConstants.DELETE_SKILL, payload: parentId }),
+    [dispatch],
+  );
+
+  const handleSkillsDragEnd = useCallback(
+    (activeId: string, overId: string) =>
+      dispatch({
+        type: actionConstants.REORDER_SKILLS,
+        payload: { activeId, overId },
+      }),
+    [dispatch],
+  );
+
+  const handleEmploymentUpdate = useCallback(
+    (parentId: string) => (fieldPayload: Field) =>
+      dispatch({
+        type: actionConstants.UPDATE_EMPLOYMENT_HISTORY,
+        payload: { parentId, fieldPayload },
+      }),
+    [dispatch],
+  );
+
+  const handleEmploymentDelete = useCallback(
+    (parentId: string) => () =>
+      dispatch({
+        type: actionConstants.DELETE_EMPLOYMENT,
+        payload: parentId,
+      }),
+    [dispatch],
+  );
+
+  const handleEmploymentDragEnd = useCallback(
+    (activeId: string, overId: string) =>
+      dispatch({
+        type: actionConstants.REORDER_EMPLOYMENT_HISTORY,
+        payload: { activeId, overId },
+      }),
+    [dispatch],
+  );
+
+  const handleEducationUpdate = useCallback(
+    (parentId: string) => (fieldPayload: Field) =>
+      dispatch({
+        type: actionConstants.UPDATE_EDUCATION,
+        payload: { parentId, fieldPayload },
+      }),
+    [dispatch],
+  );
+
+  const handleEducationDelete = useCallback(
+    (parentId: string) => () =>
+      dispatch({
+        type: actionConstants.DELETE_EDUCATION,
+        payload: parentId,
+      }),
+    [dispatch],
+  );
+
+  const handleEducationDragEnd = useCallback(
+    (activeId: string, overId: string) =>
+      dispatch({
+        type: actionConstants.REORDER_EDUCATION,
+        payload: { activeId, overId },
+      }),
+    [dispatch],
+  );
+
   return (
     <Box
       component="form"
@@ -43,79 +136,27 @@ const ResumeForm = ({
           }}
         />
         <FormSection
-          title={
-            <h3
-              style={{
-                width: "100%",
-                textAlign: "left",
-                paddingLeft: "10px",
-              }}
-            >
-              Personal Details
-            </h3>
-          }
+          title={<SectionTitle>Personal Details</SectionTitle>}
           data={resume.personal_details}
-          handleUpdate={(payload) =>
-            dispatch({
-              type: actionConstants.UPDATE_PERSONAL_DETAILS,
-              payload,
-            })
-          }
+          handleUpdate={handleUpdatePersonalDetails}
         />
         <FormSection
-          title={
-            <h3
-              style={{
-                paddingLeft: "10px",
-              }}
-            >
-              Social Media
-            </h3>
-          }
+          title={<SectionTitle>Social Media</SectionTitle>}
           data={resume.social_media}
-          handleUpdate={(payload) =>
-            dispatch({
-              type: actionConstants.UPDATE_SOCIAL_MEDIA,
-              payload,
-            })
-          }
+          handleUpdate={handleUpdateSocialMedia}
         />
 
         <SortableColumn
           columnTitle={"Skills"}
-          onDragEnd={(activeId, overId) => {
-            dispatch({
-              type: actionConstants.REORDER_SKILLS,
-              payload: {
-                activeId,
-                overId,
-              },
-            });
-          }}
+          onDragEnd={handleSkillsDragEnd}
           listItemTitle={(skill) => (
-            <Stack
-              style={{
-                padding: "20px",
-                fontSize: "13px",
-              }}
-              spacing={0.5}
-            >
-              <strong>{skill.skill}</strong>
-              <div>{skill.skill_level}</div>
-            </Stack>
+            <SortableItemSummary
+              primary={skill.skill}
+              secondary={skill.skill_level}
+            />
           )}
-          handleUpdate={(parentId: string) => (fieldPayload: Field) => {
-            dispatch({
-              type: actionConstants.UPDATE_SKILLS,
-              payload: { parentId, fieldPayload },
-            });
-          }}
-          handleDelete={(parentId: string) => () => {
-            dispatch({
-              type: actionConstants.DELETE_SKILL,
-              payload: parentId,
-            });
-          }}
+          handleUpdate={handleSkillsUpdate}
+          handleDelete={handleSkillsDelete}
           items={resume.skills}
         />
         <Button onClick={() => dispatch({ type: actionConstants.ADD_SKILL })}>
@@ -124,45 +165,19 @@ const ResumeForm = ({
 
         <SortableColumn
           columnTitle={"Employment History"}
-          onDragEnd={(activeId, overId) => {
-            dispatch({
-              type: actionConstants.REORDER_EMPLOYMENT_HISTORY,
-              payload: {
-                activeId,
-                overId,
-              },
-            });
-          }}
+          onDragEnd={handleEmploymentDragEnd}
           listItemTitle={(employment) => (
-            <Stack
-              style={{
-                padding: "20px",
-                fontSize: "13px",
-              }}
-              spacing={0.5}
-            >
-              <strong>
-                {employment.job_title}, {employment.employer}
-              </strong>
-              {employment.date_start ? (
-                <div>
-                  {employment.date_start} - {employment.date_end}
-                </div>
-              ) : null}
-            </Stack>
+            <SortableItemSummary
+              primary={`${employment.job_title}, ${employment.employer}`}
+              secondary={
+                employment.date_start
+                  ? `${employment.date_start} - ${employment.date_end}`
+                  : undefined
+              }
+            />
           )}
-          handleUpdate={(parentId: string) => (fieldPayload: Field) =>
-            dispatch({
-              type: actionConstants.UPDATE_EMPLOYMENT_HISTORY,
-              payload: { parentId, fieldPayload },
-            })
-          }
-          handleDelete={(parentId: string) => () => {
-            dispatch({
-              type: actionConstants.DELETE_EMPLOYMENT,
-              payload: parentId,
-            });
-          }}
+          handleUpdate={handleEmploymentUpdate}
+          handleDelete={handleEmploymentDelete}
           items={resume.employment_history}
         />
         <Button
@@ -175,39 +190,15 @@ const ResumeForm = ({
 
         <SortableColumn
           columnTitle={"Education"}
-          onDragEnd={(activeId, overId) => {
-            dispatch({
-              type: actionConstants.REORDER_EDUCATION,
-              payload: {
-                activeId,
-                overId,
-              },
-            });
-          }}
+          onDragEnd={handleEducationDragEnd}
           listItemTitle={(education) => (
-            <Stack
-              style={{
-                padding: "20px",
-                fontSize: "13px",
-              }}
-              spacing={0.5}
-            >
-              <strong>{education.school}</strong>
-              <div>{education.degree}</div>
-            </Stack>
+            <SortableItemSummary
+              primary={education.school}
+              secondary={education.degree}
+            />
           )}
-          handleUpdate={(parentId: string) => (fieldPayload: Field) =>
-            dispatch({
-              type: actionConstants.UPDATE_EDUCATION,
-              payload: { parentId, fieldPayload },
-            })
-          }
-          handleDelete={(parentId: string) => () => {
-            dispatch({
-              type: actionConstants.DELETE_EDUCATION,
-              payload: parentId,
-            });
-          }}
+          handleUpdate={handleEducationUpdate}
+          handleDelete={handleEducationDelete}
           items={resume.education}
         />
 
@@ -221,4 +212,4 @@ const ResumeForm = ({
   );
 };
 
-export default ResumeForm;
+export default React.memo(ResumeForm);

--- a/ui/src/components/ResumeForm/SortableColumn.tsx
+++ b/ui/src/components/ResumeForm/SortableColumn.tsx
@@ -8,6 +8,7 @@ import { ReactElement } from "react";
 import { SortableContext, useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { DndContext, closestCorners } from "@dnd-kit/core";
+import SectionTitle from "../shared/SectionTitle";
 
 interface SortableFormItemProps {
   item: FormItemSingleList;
@@ -16,12 +17,12 @@ interface SortableFormItemProps {
   handleDelete: () => void;
 }
 
-interface SortableColumnProps {
-  items: FormItemSingleList[];
-  listItemTitle: (item: any) => JSX.Element;
+interface SortableColumnProps<T extends FormItemSingleList> {
+  items: T[];
+  listItemTitle: (item: T) => JSX.Element;
   columnTitle: string;
-  handleUpdate: (parentId: string) => any;
-  handleDelete: (parentId: string) => any;
+  handleUpdate: (parentId: string) => (payload: Field) => void;
+  handleDelete: (parentId: string) => () => void;
   onDragEnd: (activeId: string, overId: string) => void;
 }
 
@@ -62,14 +63,14 @@ const SortableFormItem = ({
   );
 };
 
-const SortableColumn = ({
+const SortableColumn = <T extends FormItemSingleList>({
   items,
   listItemTitle,
   columnTitle,
   handleUpdate,
   handleDelete,
   onDragEnd,
-}: SortableColumnProps) => {
+}: SortableColumnProps<T>) => {
   return (
     <DndContext
       collisionDetection={closestCorners}
@@ -79,15 +80,7 @@ const SortableColumn = ({
         onDragEnd(active.id.toString(), over.id.toString());
       }}
     >
-      <h3
-        style={{
-          paddingLeft: "10px",
-          textAlign: "left",
-          width: "100%",
-        }}
-      >
-        {columnTitle}
-      </h3>
+      <SectionTitle>{columnTitle}</SectionTitle>
       <SortableContext items={items}>
         {items.map((item, i) => {
           return (

--- a/ui/src/components/ResumeForm/SortableItemSummary.tsx
+++ b/ui/src/components/ResumeForm/SortableItemSummary.tsx
@@ -1,0 +1,15 @@
+import Stack from "@mui/material/Stack";
+
+interface SortableItemSummaryProps {
+  primary: string;
+  secondary?: string;
+}
+
+const SortableItemSummary = ({ primary, secondary }: SortableItemSummaryProps) => (
+  <Stack style={{ padding: "20px", fontSize: "13px" }} spacing={0.5}>
+    <strong>{primary}</strong>
+    {secondary && <div>{secondary}</div>}
+  </Stack>
+);
+
+export default SortableItemSummary;

--- a/ui/src/components/shared/SectionTitle.tsx
+++ b/ui/src/components/shared/SectionTitle.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+const SectionTitle = ({ children }: { children: React.ReactNode }) => (
+  <h3 style={{ paddingLeft: "10px", textAlign: "left", width: "100%" }}>
+    {children}
+  </h3>
+);
+
+export default SectionTitle;

--- a/ui/src/constants/pdf.ts
+++ b/ui/src/constants/pdf.ts
@@ -1,0 +1,1 @@
+export const PDF_PAGE_HEIGHT_PX = 1094;

--- a/ui/src/hooks/useApi.tsx
+++ b/ui/src/hooks/useApi.tsx
@@ -12,7 +12,6 @@ const useApi = () => {
   const [error, setError] = useState<unknown>();
 
   const fetchResume = async <T,>({ method, url, body }: FetchArgs<T>) => {
-    console.log(`[${method}]: ${url}`);
     setIsLoading(true);
 
     const response = await fetch(
@@ -30,7 +29,6 @@ const useApi = () => {
       setIsLoading(false);
       return responseJson;
     } else {
-      console.log({ responseJson });
       setIsLoading(false);
       setError(responseJson);
       throw Error(responseJson);

--- a/ui/src/hooks/useBuildPdfData.tsx
+++ b/ui/src/hooks/useBuildPdfData.tsx
@@ -3,7 +3,7 @@ import { useMemo } from "react";
 import { Resume } from "../types/resumeTypes";
 
 const useBuildPdfData = (resume: Resume) => {
-  const personlDetails = useMemo(() => {
+  const personalDetails = useMemo(() => {
     return resume.personal_details.fields
       ? omit(resume.personal_details, ["fields"])
       : resume.personal_details;
@@ -38,7 +38,7 @@ const useBuildPdfData = (resume: Resume) => {
   );
 
   return {
-    personlDetails,
+    personalDetails,
     socialMedia,
     skills,
     employmentHistory,

--- a/ui/src/reducers/resumeReducer.tsx
+++ b/ui/src/reducers/resumeReducer.tsx
@@ -1,4 +1,4 @@
-import { Field, ReduxState, Resume } from "../types/resumeTypes";
+import { Field, FormItemSingleList, ReduxState, Resume } from "../types/resumeTypes";
 import { arrayMove } from "@dnd-kit/sortable";
 import {
   defaultEducation,
@@ -102,6 +102,30 @@ const updateFieldState = (fields: Field[], payload: Partial<Field>) =>
       : field,
   );
 
+const reorderById = <T extends { id: string }>(
+  array: T[],
+  activeId: string,
+  overId: string,
+): T[] => {
+  const getPos = (id: string) => array.findIndex((item) => item.id === id);
+  return arrayMove(array, getPos(activeId), getPos(overId));
+};
+
+const updateItemById = <T extends FormItemSingleList>(
+  array: T[],
+  parentId: string,
+  fieldPayload: Field,
+): T[] =>
+  array.map((item) =>
+    item.id === parentId
+      ? {
+          ...item,
+          [fieldPayload.label]: fieldPayload.value,
+          fields: updateFieldState(item.fields, fieldPayload),
+        }
+      : item,
+  );
+
 const resumeReducer = (state: ReduxState, action: Action) => {
   const updateResume = (resumeValue: Partial<Resume>) => ({
     isSaved: false,
@@ -151,28 +175,17 @@ const resumeReducer = (state: ReduxState, action: Action) => {
     }
     case actionConstants.UPDATE_SKILLS: {
       const { parentId, fieldPayload } = action.payload;
-      const skills = state.resume.skills.map((skill) =>
-        skill.id === parentId
-          ? {
-              ...skill,
-              ...{ [fieldPayload.label]: fieldPayload.value },
-              fields: updateFieldState(skill.fields, fieldPayload),
-            }
-          : skill,
-      );
-      return updateResume({ skills });
+      return updateResume({
+        skills: updateItemById(state.resume.skills, parentId, fieldPayload),
+      });
     }
     case actionConstants.ADD_SKILL: {
       return updateResume({ skills: [...state.resume.skills, defaultSkill()] });
     }
     case actionConstants.REORDER_SKILLS: {
       const { activeId, overId } = action.payload;
-      const getTaskPos = (id: string) =>
-        state.resume.skills.findIndex((skill) => skill.id === id);
-      const originalPos = getTaskPos(activeId);
-      const newPos = getTaskPos(overId);
       return updateResume({
-        skills: arrayMove(state.resume.skills, originalPos, newPos),
+        skills: reorderById(state.resume.skills, activeId, overId),
       });
     }
     case actionConstants.DELETE_SKILL: {
@@ -207,45 +220,28 @@ const resumeReducer = (state: ReduxState, action: Action) => {
     }
     case actionConstants.REORDER_EMPLOYMENT_HISTORY: {
       const { activeId, overId } = action.payload;
-      const getTaskPos = (id: string) =>
-        state.resume.employment_history.findIndex(
-          (employment) => employment.id === id,
-        );
-      const originalPos = getTaskPos(activeId);
-      const newPos = getTaskPos(overId);
-
       return updateResume({
-        employment_history: arrayMove(
+        employment_history: reorderById(
           state.resume.employment_history,
-          originalPos,
-          newPos,
+          activeId,
+          overId,
         ),
       });
     }
     case actionConstants.REORDER_EDUCATION: {
       const { activeId, overId } = action.payload;
-      const getTaskPos = (id: string) =>
-        state.resume.education.findIndex((edu) => edu.id === id);
-      const originalPos = getTaskPos(activeId);
-      const newPos = getTaskPos(overId);
-
       return updateResume({
-        education: arrayMove(state.resume.education, originalPos, newPos),
+        education: reorderById(state.resume.education, activeId, overId),
       });
     }
     case actionConstants.UPDATE_EMPLOYMENT_HISTORY: {
       const { parentId, fieldPayload } = action.payload;
-      const newState = state.resume.employment_history.map((employment) =>
-        employment.id === parentId
-          ? {
-              ...employment,
-              ...{ [fieldPayload.label]: fieldPayload.value },
-              fields: updateFieldState(employment.fields, fieldPayload),
-            }
-          : employment,
-      );
       return updateResume({
-        employment_history: newState,
+        employment_history: updateItemById(
+          state.resume.employment_history,
+          parentId,
+          fieldPayload,
+        ),
       });
     }
     case actionConstants.ADD_EDUCATION: {
@@ -255,18 +251,8 @@ const resumeReducer = (state: ReduxState, action: Action) => {
     }
     case actionConstants.UPDATE_EDUCATION: {
       const { parentId, fieldPayload } = action.payload;
-      const newState = state.resume.education.map((education) =>
-        education.id === parentId
-          ? {
-              ...education,
-              ...{ [fieldPayload.label]: fieldPayload.value },
-              fields: updateFieldState(education.fields, fieldPayload),
-            }
-          : education,
-      );
-
       return updateResume({
-        education: newState,
+        education: updateItemById(state.resume.education, parentId, fieldPayload),
       });
     }
     default:


### PR DESCRIPTION
UI: remove debug console.logs, drop no-op useMemo, extract PDF_PAGE_HEIGHT_PX constant, fix personlDetails typo, wrap PdfView and ResumeForm in React.memo, add useCallback for all ResumeForm dispatch handlers, fix any types in SortableColumn with generics, extract reorderById and updateItemById reducer helpers, add SortableItemSummary and SectionTitle shared components, surface API errors via MUI Snackbar instead of silent console.log, add try-catch to Header handleDelete.

Server: add try-catch to getAllResumes and getSingleResume, standardize all catch blocks to use next(error) via error middleware, handle Prisma P2025 as 404 in updateResume and deleteResume, remove dead if(!resume) guards, fix createResume to return 201, add next param to deleteResume, use select in getListIds, fix any CORS types, remove unused Prisma import, make query logging dev-only, remove console.logs from controllers and error middleware.

Also add .claude/launch.json for ui (port 3000) and server (port 8080) dev server configurations.