### PR TITLE
Organize first pass of UI styles

### DIFF
--- a/ui/src/components/PdfView/PdfView.css
+++ b/ui/src/components/PdfView/PdfView.css
@@ -90,6 +90,11 @@
     margin: 4px 0;
   }
 
+  .skillBotTheme {
+    border: unset;
+    padding: unset;
+  }
+
   .nameTitleContainer {
     width: 100%;
     margin: 42px 0;
@@ -104,6 +109,17 @@
     margin: auto;
     padding: 46px;
   }
+  .nameTitleBotTheme {
+    background-image: unset;
+    border: unset;
+    padding: unset;
+  }
+
+  .educationRow {
+    display: flex;
+    justify-content: space-between;
+  }
+
   .name {
     font-size: 22px;
     margin-bottom: 9px;

--- a/ui/src/components/PdfView/PdfView.tsx
+++ b/ui/src/components/PdfView/PdfView.tsx
@@ -37,18 +37,7 @@ const PdfView = React.forwardRef<HTMLDivElement | null, PdfViewProps>(
         <div ref={ref}>
           <Stack ref={pageRef} className="page">
             <div className="nameTitleContainer">
-              <div
-                className="nameTitle"
-                style={
-                  isBotTheme
-                    ? {
-                        backgroundImage: "unset",
-                        border: "unset",
-                        padding: "unset",
-                      }
-                    : undefined
-                }
-              >
+              <div className={`nameTitle${isBotTheme ? " nameTitleBotTheme" : ""}`}>
                 <div className="name title">
                   {personalDetails.first_name} {personalDetails.last_name}
                 </div>
@@ -107,17 +96,7 @@ const PdfView = React.forwardRef<HTMLDivElement | null, PdfViewProps>(
                   <div className="title">Skills</div>
                   {skills.map(({ skill, skill_level }, i) => (
                     <Fragment key={`${skill}-${i}`}>
-                      <div
-                        className="skill"
-                        style={
-                          isBotTheme
-                            ? {
-                                border: "unset",
-                                padding: "unset",
-                              }
-                            : undefined
-                        }
-                      >
+                      <div className={`skill${isBotTheme ? " skillBotTheme" : ""}`}>
                         {skill}
                       </div>
                       {/* <div>{skill_level}</div> */}
@@ -171,13 +150,7 @@ const PdfView = React.forwardRef<HTMLDivElement | null, PdfViewProps>(
                   <div className="title">Education</div>
                   {education.map((ed, i) => {
                     return (
-                      <div
-                        key={i}
-                        style={{
-                          display: "flex",
-                          justifyContent: "space-between",
-                        }}
-                      >
+                      <div key={i} className="educationRow">
                         <div className="subTitle">
                           {ed.degree}, {ed.school}
                         </div>

--- a/ui/src/components/ResumeForm/FormSection.tsx
+++ b/ui/src/components/ResumeForm/FormSection.tsx
@@ -11,6 +11,7 @@ import { Field, FormItemSingle } from "../../types/resumeTypes";
 import ReactQuill from "react-quill";
 import { styled } from "@mui/material/styles";
 import { ReactElement, useState } from "react";
+import "./ResumeForm.css";
 
 interface FormSectionProps {
   data: FormItemSingle;
@@ -38,7 +39,7 @@ export const FormSection = ({
 }: FormSectionProps) => {
   const [expanded, setExpanded] = useState(false);
   return (
-    <Card style={{ width: "100%", margin: "12px auto" }}>
+    <Card className="formSectionCard">
       <Stack
         direction={"row"}
         alignItems={"center"}
@@ -64,7 +65,7 @@ export const FormSection = ({
           const { id, label, type, value } = field;
           if (type === "html") {
             return (
-              <div key={id} style={{ width: "100%", padding: "27px" }}>
+              <div key={id} className="formSectionHtmlField">
                 <InputLabel>{capitalize(label.replace("_", " "))}</InputLabel>
                 <ReactQuill
                   theme="snow"

--- a/ui/src/components/ResumeForm/ResumeForm.css
+++ b/ui/src/components/ResumeForm/ResumeForm.css
@@ -6,3 +6,24 @@
   overflow: scroll;
   height: 92vh;
 }
+
+.sectionTitle {
+  width: 100%;
+  padding-left: 10px;
+  text-align: left;
+}
+
+.sortableItemSummary {
+  padding: 20px;
+  font-size: 13px;
+}
+
+.formSectionCard {
+  width: 100%;
+  margin: 12px auto;
+}
+
+.formSectionHtmlField {
+  width: 100%;
+  padding: 27px;
+}

--- a/ui/src/components/ResumeForm/SortableItemSummary.tsx
+++ b/ui/src/components/ResumeForm/SortableItemSummary.tsx
@@ -1,4 +1,5 @@
 import Stack from "@mui/material/Stack";
+import "./ResumeForm.css";
 
 interface SortableItemSummaryProps {
   primary: string;
@@ -6,7 +7,7 @@ interface SortableItemSummaryProps {
 }
 
 const SortableItemSummary = ({ primary, secondary }: SortableItemSummaryProps) => (
-  <Stack style={{ padding: "20px", fontSize: "13px" }} spacing={0.5}>
+  <Stack className="sortableItemSummary" spacing={0.5}>
     <strong>{primary}</strong>
     {secondary && <div>{secondary}</div>}
   </Stack>

--- a/ui/src/components/shared/SectionTitle.tsx
+++ b/ui/src/components/shared/SectionTitle.tsx
@@ -1,9 +1,8 @@
 import React from "react";
+import "../ResumeForm/ResumeForm.css";
 
 const SectionTitle = ({ children }: { children: React.ReactNode }) => (
-  <h3 style={{ paddingLeft: "10px", textAlign: "left", width: "100%" }}>
-    {children}
-  </h3>
+  <h3 className="sectionTitle">{children}</h3>
 );
 
 export default SectionTitle;


### PR DESCRIPTION
## Summary\n- move several static inline styles into existing component CSS files\n- keep dynamic MUI/prop-driven styling in code\n- convert PdfView bot-theme and education row styles to class-based styling\n\n## Validation\n- npm --prefix ui run build\n\n## Notes\nThis is an intentionally small first pass focused on reducing inline styles without changing the overall styling approach or introducing new tooling.